### PR TITLE
feat(#36): ignore_file, ignore_issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ testing_logger = "0.1.1"
 
 [dev-dependencies]
 assert_cmd = "2.0.14"
+tempdir = "0.3.7"
 
 [features]
 default = ["cli"]

--- a/src/args/ignore_facts.rs
+++ b/src/args/ignore_facts.rs
@@ -22,9 +22,6 @@
 use std::collections::HashMap;
 
 /// Parse facts from list of strings (lines).
-// @todo #27:30min Read ignore.ghiqc file as list of strings.
-//  We should read file first in the main.rs, and then pass list of strings in
-//  parse_facts function.
 pub fn parse_facts(content: Vec<String>) -> HashMap<String, Vec<String>> {
     let mut facts: HashMap<String, Vec<String>> = HashMap::new();
     let mut author = vec![];

--- a/src/args/ignore_file.rs
+++ b/src/args/ignore_file.rs
@@ -8,23 +8,23 @@ use std::path::Path;
 /// `name` Ignore file name
 #[derive(Clone)]
 pub struct IgnoreFile {
-    name: String,
+    path: String,
 }
 
 impl IgnoreFile {
     /// New ignore file.
-    pub fn new(name: String) -> IgnoreFile {
-        IgnoreFile { name }
+    pub fn new(path: String) -> IgnoreFile {
+        IgnoreFile { path }
     }
 
     /// Is file exists?
-    pub fn exists(self) -> bool {
-        Path::new(&self.name).exists()
+    pub fn exists(&self) -> bool {
+        Path::new(&self.path).exists()
     }
 
     /// Facts.
-    pub fn facts(self) -> HashMap<String, Vec<String>> {
-        match File::open(self.name.clone()) {
+    pub fn facts(&self) -> HashMap<String, Vec<String>> {
+        match File::open(Path::new(&self.path.clone())) {
             Ok(file) => {
                 let reader = BufReader::new(file);
                 let facts: Vec<String> =
@@ -32,7 +32,7 @@ impl IgnoreFile {
                 parse_facts(facts)
             }
             Err(err) => {
-                panic!("Can not read facts from {}, due to: {}", self.name, err)
+                panic!("Can not read facts from {}, due to: {}", self.path, err)
             }
         }
     }
@@ -43,6 +43,7 @@ mod tests {
     use crate::args::ignore_file::IgnoreFile;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
+    use std::fs::File;
     use tempdir::TempDir;
 
     #[test]
@@ -50,10 +51,36 @@ mod tests {
         let temp = TempDir::new("temp")?;
         let name = "ignore.ghiqc";
         let path = temp.path().join(name);
+        File::create(path.clone()).expect("Can not create a file");
         let ignore = IgnoreFile::new(String::from(
             path.to_str().expect("Path does not exists"),
         ));
-        assert_that!(ignore.name.is_empty(), is(equal_to(false)));
+        assert_that!(ignore.path.is_empty(), is(equal_to(false)));
+        Ok(())
+    }
+
+    #[test]
+    fn returns_true_if_exists() -> Result<()> {
+        let temp = TempDir::new("temp")?;
+        let name = "ignore.ghiqc";
+        let path = temp.path().join(name);
+        File::create(path.clone()).expect("Can not create a file");
+        let ignore = IgnoreFile::new(String::from(
+            path.to_str().expect("Path does not exists"),
+        ));
+        assert_that!(ignore.exists(), is(equal_to(true)));
+        Ok(())
+    }
+
+    #[test]
+    fn returns_false_if_absent() -> Result<()> {
+        let temp = TempDir::new("temp")?;
+        let name = "ignore.ghiqc";
+        let path = temp.path().join(name);
+        let ignore = IgnoreFile::new(String::from(
+            path.to_str().expect("Path does not exists"),
+        ));
+        assert_that!(ignore.exists(), is(equal_to(false)));
         Ok(())
     }
 }

--- a/src/args/ignore_file.rs
+++ b/src/args/ignore_file.rs
@@ -1,0 +1,34 @@
+use crate::args::ignore_facts::parse_facts;
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+
+/// Ignore file.
+/// `name` Ignore file name
+#[derive(Clone)]
+pub struct IgnoreFile {
+    name: String,
+}
+
+impl IgnoreFile {
+    /// New ignore file.
+    pub fn new(name: String) -> IgnoreFile {
+        IgnoreFile { name }
+    }
+
+    /// Is file exists?
+    pub fn exists(self) -> bool {
+        Path::new(&self.name).exists()
+    }
+
+    /// Facts.
+    pub fn facts(self) -> HashMap<String, Vec<String>> {
+        let file = File::open(self.name);
+        let reader = BufReader::new(file);
+        let facts: Vec<String> = reader.lines()
+            .filter_map(Result::ok)
+            .collect();
+        parse_facts(facts)
+    }
+}

--- a/src/args/ignore_file.rs
+++ b/src/args/ignore_file.rs
@@ -1,3 +1,24 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 use crate::args::ignore_facts::parse_facts;
 use std::collections::HashMap;
 use std::fs::File;

--- a/src/args/ignore_file.rs
+++ b/src/args/ignore_file.rs
@@ -49,7 +49,7 @@ impl IgnoreFile {
             Ok(file) => {
                 let reader = BufReader::new(file);
                 let facts: Vec<String> =
-                    reader.lines().filter_map(Result::ok).collect();
+                    reader.lines().map_while(Result::ok).collect();
                 parse_facts(facts)
             }
             Err(err) => {
@@ -68,6 +68,7 @@ mod tests {
     use tempdir::TempDir;
 
     #[test]
+    #[allow(clippy::question_mark_used)]
     fn creates_new_ignore_file() -> Result<()> {
         let temp = TempDir::new("temp")?;
         let name = "ignore.ghiqc";
@@ -81,6 +82,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::question_mark_used)]
     fn returns_true_if_exists() -> Result<()> {
         let temp = TempDir::new("temp")?;
         let name = "ignore.ghiqc";
@@ -94,6 +96,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::question_mark_used)]
     fn returns_false_if_absent() -> Result<()> {
         let temp = TempDir::new("temp")?;
         let name = "ignore.ghiqc";

--- a/src/args/ignore_issue.rs
+++ b/src/args/ignore_issue.rs
@@ -1,3 +1,24 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2024 Aliaksei Bialiauski
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 use crate::args::ignore_facts::{ignores_dim, ignores_title};
 use crate::args::ignore_file::IgnoreFile;
 use crate::github::github_issue::GithubIssue;
@@ -8,20 +29,46 @@ use crate::github::github_issue::GithubIssue;
 pub fn ignore_issue(issue: GithubIssue, file: IgnoreFile) -> bool {
     let facts = file.facts();
     let mut result = false;
+    let labels = issue.clone().labels();
+    for label in labels {
+        if ignores_dim(label, String::from("label"), facts.clone()) {
+            result = true
+        }
+    }
     if ignores_title(issue.clone().title(), facts.clone()) {
         result = true
-    } else if ignores_dim(
-        issue.author(),
-        String::from("author"),
-        facts.clone(),
-    ) {
-        result = true
-    } else if ignores_dim(
-        String::from(""),
-        String::from("label"),
-        facts,
-    ) {
+    } else if ignores_dim(issue.author(), String::from("author"), facts.clone())
+    {
         result = true
     }
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::github::github::github;
+    use crate::github::github_issue::GithubIssue;
+    use crate::github::issue::Issue;
+    use anyhow::Result;
+    use hamcrest::{equal_to, is, HamcrestMatcher};
+    use crate::args::ignore_file::IgnoreFile;
+    use crate::args::ignore_issue::ignore_issue;
+
+    // @todo #36:30min Enable returns_true_on_ignore test when fake GitHub
+    //  instance will be ready. After fake GitHub instance will be connected,
+    //  we should pass fake credentials and repo information in order to test
+    //  #ignore_issue.
+    #[ignore]
+    #[tokio::test]
+    async fn returns_true_on_ignore() -> Result<()> {
+        let issue = GithubIssue::new(
+            Issue::new(String::from("jeff/foo"), 1),
+            github(String::from("<gh token here>")),
+        )
+        .await;
+        let file = IgnoreFile::new(String::from("ignore.ghiqc"));
+        let ignore = ignore_issue(issue, file);
+        assert_that!(ignore, is(equal_to(true)));
+        Ok(())
+    }
 }

--- a/src/args/ignore_issue.rs
+++ b/src/args/ignore_issue.rs
@@ -1,0 +1,27 @@
+use crate::args::ignore_facts::{ignores_dim, ignores_title};
+use crate::args::ignore_file::IgnoreFile;
+use crate::github::github_issue::GithubIssue;
+
+/// Ignore issue?
+/// * `issue`: Issue
+/// * `file`: File with facts
+pub fn ignore_issue(issue: GithubIssue, file: IgnoreFile) -> bool {
+    let facts = file.facts();
+    let mut result = false;
+    if ignores_title(issue.clone().title(), facts.clone()) {
+        result = true
+    } else if ignores_dim(
+        issue.author(),
+        String::from("author"),
+        facts.clone(),
+    ) {
+        result = true
+    } else if ignores_dim(
+        issue.labels(),
+        String::from("label"),
+        facts,
+    ) {
+        result = true
+    }
+    result
+}

--- a/src/args/ignore_issue.rs
+++ b/src/args/ignore_issue.rs
@@ -17,7 +17,7 @@ pub fn ignore_issue(issue: GithubIssue, file: IgnoreFile) -> bool {
     ) {
         result = true
     } else if ignores_dim(
-        issue.labels(),
+        String::from(""),
         String::from("label"),
         facts,
     ) {

--- a/src/args/ignore_issue.rs
+++ b/src/args/ignore_issue.rs
@@ -26,6 +26,7 @@ use crate::github::github_issue::GithubIssue;
 /// Ignore issue?
 /// * `issue`: Issue
 /// * `file`: File with facts
+#[allow(clippy::if_same_then_else)]
 pub fn ignore_issue(issue: GithubIssue, file: IgnoreFile) -> bool {
     let facts = file.facts();
     let mut result = false;
@@ -46,13 +47,13 @@ pub fn ignore_issue(issue: GithubIssue, file: IgnoreFile) -> bool {
 
 #[cfg(test)]
 mod tests {
+    use crate::args::ignore_file::IgnoreFile;
+    use crate::args::ignore_issue::ignore_issue;
     use crate::github::github::github;
     use crate::github::github_issue::GithubIssue;
     use crate::github::issue::Issue;
     use anyhow::Result;
     use hamcrest::{equal_to, is, HamcrestMatcher};
-    use crate::args::ignore_file::IgnoreFile;
-    use crate::args::ignore_issue::ignore_issue;
 
     // @todo #36:30min Enable returns_true_on_ignore test when fake GitHub
     //  instance will be ready. After fake GitHub instance will be connected,

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -25,7 +25,7 @@ pub mod cli;
 pub mod env;
 /// Ignore issue based on facts.
 pub mod ignore_facts;
-/// Ignore issue.
-pub mod ignore_issue;
 /// Ignore file.
 pub mod ignore_file;
+/// Ignore issue.
+pub mod ignore_issue;

--- a/src/args/mod.rs
+++ b/src/args/mod.rs
@@ -25,3 +25,7 @@ pub mod cli;
 pub mod env;
 /// Ignore issue based on facts.
 pub mod ignore_facts;
+/// Ignore issue.
+pub mod ignore_issue;
+/// Ignore file.
+pub mod ignore_file;

--- a/src/github/github_issue.rs
+++ b/src/github/github_issue.rs
@@ -28,6 +28,9 @@ pub struct GithubIssue {
     origin: octocrab::models::issues::Issue,
 }
 
+// @todo #36:30min Pass Fake GitHub in order to test GitHubIssue.
+//  We should configure this struct not only to accept real GitHub instance,
+//  but fake one too. This should boost our testing abilities.
 impl GithubIssue {
     /// GitHub issue from origin.
     pub async fn new(origin: Issue, github: Octocrab) -> GithubIssue {
@@ -57,5 +60,14 @@ impl GithubIssue {
     /// Issue title.
     pub fn title(self) -> String {
         self.origin.title
+    }
+
+    /// Issue labels.
+    pub fn labels(self) -> Vec<String> {
+        let mut result = vec![];
+        for label in self.origin.labels {
+            result.push(label.name)
+        }
+        result
     }
 }

--- a/src/github/github_issue.rs
+++ b/src/github/github_issue.rs
@@ -37,6 +37,11 @@ impl GithubIssue {
 }
 
 impl GithubIssue {
+    /// Issue number.
+    pub fn number(self) -> u64 {
+        self.origin.number
+    }
+
     /// Issue body.
     pub fn body(self) -> String {
         self.origin
@@ -47,5 +52,10 @@ impl GithubIssue {
     /// GitHub nickname of issue author.
     pub fn author(self) -> String {
         self.origin.user.login
+    }
+
+    /// Issue title.
+    pub fn title(self) -> String {
+        self.origin.title
     }
 }

--- a/src/github/github_issue.rs
+++ b/src/github/github_issue.rs
@@ -30,7 +30,8 @@ pub struct GithubIssue {
 
 // @todo #36:30min Pass Fake GitHub in order to test GitHubIssue.
 //  We should configure this struct not only to accept real GitHub instance,
-//  but fake one too. This should boost our testing abilities.
+//  but fake one too. This should boost our testing abilities. This functionality
+//  should affect args.ignore_issue.rs too.
 impl GithubIssue {
     /// GitHub issue from origin.
     pub async fn new(origin: Issue, github: Octocrab) -> GithubIssue {

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,6 @@ extern crate hamcrest;
 
 use crate::args::cli::Cli;
 use crate::args::env::env;
-use crate::args::ignore_facts::{ignores_title, parse_facts};
 use crate::args::ignore_file::IgnoreFile;
 use crate::args::ignore_issue::ignore_issue;
 use crate::github::github::github;
@@ -41,11 +40,7 @@ use crate::report::report::Report;
 use crate::report::report_fork::ReportFork;
 use crate::report::tagged_response::tagged;
 use clap::Parser;
-use hamcrest::is;
 use log::{debug, info};
-use std::io::{BufRead, BufReader};
-use std::path::Path;
-use tokio::io::AsyncBufReadExt;
 
 /// Arguments.
 pub mod args;


### PR DESCRIPTION
In this pull I've introduced `ignore_file` struct to handle `ignore.ghiqc` file, and pass facts into `ignore_issue`.

History:
- **feat(#36): no labels, no tests**
- **feat(#36): creates_new_ignore_file, tempdir**
- **feat(#36): ignore_file.exists()**
- **feat(#36): labels, puzzle**
- **feat(#36): ignore_issue disabled test, wait for fake github**
- **feat(#36): clean for cargo**


<!-- start pr-codex -->

---

## PR-Codex overview
The focus of this PR is to enhance issue handling by introducing the ability to ignore certain issues based on predefined facts in an ignore file.

### Detailed summary
- Added `ignore_file` module to handle ignoring issues based on facts in a file.
- Introduced `IgnoreFile` struct to manage ignore file operations.
- Implemented logic to ignore issues based on facts from the ignore file.
- Updated `ignore_issue` function to check if an issue should be ignored based on facts.
- Added tests for the `IgnoreFile` functionality.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->